### PR TITLE
Add Twilio Flex SSO setup guide

### DIFF
--- a/niorlusx_call_service/.env.example
+++ b/niorlusx_call_service/.env.example
@@ -1,0 +1,4 @@
+TWILIO_ACCOUNT_SID=your_twilio_sid
+TWILIO_AUTH_TOKEN=your_twilio_token
+TWILIO_PHONE_NUMBER=+10000000000
+OPENAI_API_KEY=your_openai_key

--- a/niorlusx_call_service/.github/workflows/deploy.yml
+++ b/niorlusx_call_service/.github/workflows/deploy.yml
@@ -1,0 +1,12 @@
+name: Deploy
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - run: pip install -r niorlusx_call_service/requirements.txt
+      - run: python niorlusx_call_service/app.py & sleep 5 && pkill -f app.py

--- a/niorlusx_call_service/Dockerfile
+++ b/niorlusx_call_service/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "app.py"]

--- a/niorlusx_call_service/README.md
+++ b/niorlusx_call_service/README.md
@@ -1,0 +1,39 @@
+# Niorlusx AI Call Service
+
+This example Flask application demonstrates a minimal integration of Twilio voice calls with OpenAI's Whisper, GPT-4o and TTS APIs.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your credentials.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Run the service:
+   ```bash
+   ./start.sh
+   ```
+4. Configure your Twilio number's voice webhook to `https://<your-url>/incoming_call`.
+
+Call logs are appended to `call_logs.txt`.
+
+## Additional Documentation
+
+- `docs/carrier_aggregator.md` – steps for registering with a carrier aggregator with debug statements.
+- `docs/sip_cheat_sheet.md` – Twilio SIP setup instructions including debug prints.
+- `docs/metrics_example.py` – example endpoint for real-time call metrics with a dashboard placeholder.
+- `docs/twilio_flex_sso.md` – how to configure your IdP for Twilio Flex SSO.
+
+Repository layout:
+
+```
+app.py
+requirements.txt
+.env.example
+start.sh
+README.md
+twiml.xml
+Dockerfile
+.github/workflows/deploy.yml
+call_logs.txt (auto-created)
+```

--- a/niorlusx_call_service/app.py
+++ b/niorlusx_call_service/app.py
@@ -1,0 +1,94 @@
+import os
+from datetime import datetime
+from flask import Flask, request, send_file
+from twilio.twiml.voice_response import VoiceResponse
+from openai import OpenAI
+from dotenv import load_dotenv
+
+load_dotenv()
+
+TWILIO_ACCOUNT_SID = os.getenv('TWILIO_ACCOUNT_SID')
+TWILIO_AUTH_TOKEN = os.getenv('TWILIO_AUTH_TOKEN')
+TWILIO_PHONE_NUMBER = os.getenv('TWILIO_PHONE_NUMBER')
+OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
+
+app = Flask(__name__)
+openai_client = OpenAI(api_key=OPENAI_API_KEY)
+
+conversation_history = {}
+
+def get_history(call_sid):
+    if call_sid not in conversation_history:
+        conversation_history[call_sid] = [
+            {
+                "role": "system",
+                "content": (
+                    "You are Niorlusx AI, an emotionally adaptive voice agent."
+                ),
+            }
+        ]
+    return conversation_history[call_sid]
+
+@app.route("/incoming_call", methods=["POST"])
+def incoming_call():
+    call_sid = request.values.get("CallSid")
+    get_history(call_sid)
+    resp = VoiceResponse()
+    resp.say("Welcome to Niorlusx AI Call Service. Please speak after the beep.")
+    resp.record(
+        timeout=5,
+        transcribe=True,
+        transcribeCallback="/handle_speech",
+        playBeep=True,
+    )
+    resp.redirect("/handle_speech")
+    return str(resp)
+
+@app.route("/handle_speech", methods=["POST"])
+def handle_speech():
+    call_sid = request.values.get("CallSid")
+    text = request.values.get("TranscriptionText")
+    resp = VoiceResponse()
+    if not call_sid:
+        resp.say("Missing call info.")
+        return str(resp)
+    if text:
+        history = get_history(call_sid)
+        history.append({"role": "user", "content": text})
+        chat = openai_client.chat.completions.create(
+            model="gpt-4o", messages=history
+        )
+        ai_text = chat.choices[0].message.content
+        history.append({"role": "assistant", "content": ai_text})
+        audio_path = f"/tmp/resp_{call_sid}.mp3"
+        with openai_client.audio.speech.with_streaming_response.create(
+            model="tts-1", voice="nova", input=ai_text
+        ) as stream:
+            stream.stream_to_file(audio_path)
+        with open("call_logs.txt", "a") as log:
+            log.write(f"[{datetime.utcnow()}] {call_sid}: {text}\n")
+        resp.play(url=request.url_root + f"play_audio?sid={call_sid}")
+        resp.record(
+            timeout=5, transcribe=True, transcribeCallback="/handle_speech", playBeep=True
+        )
+    else:
+        resp.say("I didn't catch that. Please repeat.")
+        resp.record(
+            timeout=5, transcribe=True, transcribeCallback="/handle_speech", playBeep=True
+        )
+    return str(resp)
+
+@app.route("/play_audio")
+def play_audio():
+    sid = request.args.get("sid")
+    path = f"/tmp/resp_{sid}.mp3"
+    return send_file(path, mimetype="audio/mpeg")
+
+@app.route("/")
+def index():
+    return "Niorlusx AI Call Service running"
+
+if __name__ == "__main__":
+    if not os.path.exists("/tmp"):
+        os.makedirs("/tmp")
+    app.run(host="0.0.0.0", port=8000)

--- a/niorlusx_call_service/docs/carrier_aggregator.md
+++ b/niorlusx_call_service/docs/carrier_aggregator.md
@@ -1,0 +1,29 @@
+# Carrier Aggregator Integration
+
+The following steps outline how to connect a carrier aggregator to the
+Niorlusx AI Call Service. Debug statements mirror what you might log while
+setting things up.
+
+1. **Choose and Register**
+   ```python
+   print("[DEBUG] Selected aggregator and started registration.")
+   ```
+   - Apply with a provider such as mVoice, Red Telecom or Boku.
+   - Provide forecasts and compliance documents.
+   - Once approved you'll receive a premium-rate `190x` number.
+   - Set payout bank details (Australian bank account).
+
+2. **Configuration**
+   ```python
+   print("[DEBUG] Configuring premium-rate number and SIP trunk.")
+   ```
+   - Point the issued premium number to your Twilio SIP domain.
+   - The aggregator will handle caller billing automatically.
+   - You receive monthly or bi-weekly payout reports.
+
+3. **Pricing Announcement**
+   ```python
+   print("[DEBUG] Pricing announcement setup step.")
+   ```
+   - Play an upfront disclosure such as `$4.95 per minute` using a TwiML
+     `<Say>` verb or a custom audio file.

--- a/niorlusx_call_service/docs/metrics_example.py
+++ b/niorlusx_call_service/docs/metrics_example.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+from fastapi import FastAPI, Form
+from fastapi.responses import PlainTextResponse
+
+app = FastAPI()
+
+@app.post("/voice", response_class=PlainTextResponse)
+async def voice_reply(SpeechResult: str = Form(None)):
+    print(f"[DEBUG] Received SpeechResult: {SpeechResult}")
+    log_entry = f"[{datetime.utcnow()}] Incoming text: {SpeechResult}"
+    with open("call_logs.txt", "a") as log_file:
+        log_file.write(log_entry + "\n")
+    return "OK"
+
+# Future dashboard integration
+print("[DEBUG] Metrics dashboard placeholder added.")

--- a/niorlusx_call_service/docs/sip_cheat_sheet.md
+++ b/niorlusx_call_service/docs/sip_cheat_sheet.md
@@ -1,0 +1,26 @@
+# SIP Setup Cheat Sheet
+
+Use this short guide to configure a Twilio SIP domain and route calls to the
+AI backend. Debug print statements illustrate key stages.
+
+1. **Setup Twilio SIP Domain**
+   ```python
+   print("[DEBUG] Starting SIP domain setup in Twilio.")
+   ```
+   - Create a domain named `niorlusx-voice-service`.
+   - SIP URI: `niorlusx-voice-service.sip.twilio.com`.
+
+   ```python
+   print("[DEBUG] SIP domain configured with authentication.")
+   ```
+
+2. **Authentication**
+   - Use an IP ACL or create credentials such as `niorlusx_sip` and a password.
+
+3. **Configure Voice URL**
+   - Point to your backend endpoint:
+     `https://your-server-domain/voice`
+
+4. **Call Handling**
+   - Inbound calls → SIP → AI backend → TwiML response.
+

--- a/niorlusx_call_service/docs/twilio_flex_sso.md
+++ b/niorlusx_call_service/docs/twilio_flex_sso.md
@@ -1,0 +1,31 @@
+# Twilio Flex SSO Setup Guide
+
+This guide walks through adding Twilio Flex as a SAML application in your identity provider (IdP). You will need administrator access to your IdP.
+
+## Information from Twilio Flex
+- **Entity ID:** `urn:flex:JQ9668343b2b51f296bf788f89201c9947`
+- **ACS URL:** `https://login.flex.us1.twilio.com/login/callback?connection=JQ9668343b2b51f296bf788f89201c9947`
+
+## Steps
+1. **Create a new SAML application** in your IdP dashboard.
+2. **Enter the Flex details** when prompted:
+   - Entity ID as above.
+   - Assertion Consumer Service (ACS) URL as above.
+   - Name ID format: email address.
+3. **Configure attribute mappings** so that the SAML assertion includes the following mandatory attributes:
+   - `full name`
+   - `email`
+   - `Flex role` (values: `agent`, `supervisor`, or `administrator`)
+4. **Download your IdP metadata** or copy the following values which Flex needs:
+   - X.509 certificate
+   - Single sign-on URL
+   - Default redirect URL (optional)
+   - Trusted URLs (optional)
+5. **Provide the IdP values** in the Flex SSO settings page of the Twilio Console.
+6. **Assign users** to this application in your IdP so they can log in to Flex.
+
+## Next Steps
+- Test SSO login by accessing Flex through the IdP.
+- If issues arise, check that clock skew between the IdP and Flex is minimal and that attribute names match exactly.
+
+For more detail see Twilio's official documentation on [Configuring SSO for Flex](https://www.twilio.com/docs/flex/admin-guide/setup/single-sign-on).

--- a/niorlusx_call_service/requirements.txt
+++ b/niorlusx_call_service/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+openai
+python-dotenv
+twilio

--- a/niorlusx_call_service/start.sh
+++ b/niorlusx_call_service/start.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python app.py

--- a/niorlusx_call_service/twiml.xml
+++ b/niorlusx_call_service/twiml.xml
@@ -1,0 +1,4 @@
+<Response>
+    <Say>Welcome to Niorlusx AI Call Service.</Say>
+    <Record timeout="5" playBeep="true" />
+</Response>


### PR DESCRIPTION
## Summary
- document how to configure an IdP for Twilio Flex SSO
- link to the new SSO guide from the README

## Testing
- `python -m py_compile niorlusx_call_service/app.py`


------
https://chatgpt.com/codex/tasks/task_e_687469ead604832bb0d4793176b3329a