### PR TITLE
Add Termux setup doc

### DIFF
--- a/niorlusx_call_service/README.md
+++ b/niorlusx_call_service/README.md
@@ -24,6 +24,7 @@ Call logs are appended to `call_logs.txt`.
 - `docs/metrics_example.py` – example endpoint for real-time call metrics with a dashboard placeholder.
 - `docs/twilio_flex_sso.md` – how to configure your IdP for Twilio Flex SSO.
 - `docs/duckdns_cron.md` – configure a DuckDNS update script with cron.
+- `docs/termux_guide.md` - instructions for running the service in Termux.
 
 Repository layout:
 

--- a/niorlusx_call_service/docs/termux_guide.md
+++ b/niorlusx_call_service/docs/termux_guide.md
@@ -1,0 +1,40 @@
+# Running the Call Service in Termux
+
+This guide outlines how to run the Flask-based Niorlusx AI call service directly on an Android device using the Termux app.
+
+## Step 1: Prepare your workspace
+```bash
+cd ~
+mkdir -p niorlusx-call-service
+cd niorlusx-call-service
+```
+
+## Step 2: Install dependencies
+```bash
+pkg install python -y
+pip install --upgrade pip
+pip install flask twilio openai python-dotenv
+mkdir -p $HOME/niorlusx_logs
+```
+
+## Step 3: Create the `.env` file
+```bash
+cat > .env <<'EOT'
+OPENAI_API_KEY=[KEY REDACTED]
+EOT
+```
+Replace `[KEY REDACTED]` with your actual API key locally.
+
+## Step 4: Write the Flask app
+Copy the `app.py` from this repository into your Termux directory. A log file will be written to `$HOME/niorlusx_logs/app.log`.
+
+## Step 5: Run the service
+```bash
+export FLASK_APP=app.py
+flask run --host=0.0.0.0 --port=8080
+```
+Leave the session running and point your Twilio Voice webhook to:
+```
+http://<YOUR_PUBLIC_IP>:8080/voice
+```
+Check `$HOME/niorlusx_logs/app.log` for call details and errors.


### PR DESCRIPTION
## Summary
- add Termux guide detailing how to run the Flask app on Android
- reference the new guide from the README

## Testing
- `python -m py_compile niorlusx_call_service/app.py`
- `python -m py_compile niorlusx_call_service/docs/metrics_example.py`


------
https://chatgpt.com/codex/tasks/task_e_687c47b4663c832b834ca8d6986eefb7